### PR TITLE
ReadCloser and Response Error handling

### DIFF
--- a/shell.go
+++ b/shell.go
@@ -72,7 +72,7 @@ func (s *Shell) ID(peer ...string) (*IdOutput, error) {
 	return out, nil
 }
 
-// Cat the content at the given path
+// Cat the content at the given path. Callers need to drain and close the returned reader after usage.
 func (s *Shell) Cat(path string) (io.ReadCloser, error) {
 	resp, err := NewRequest(s.url, "cat", path).Send(s.httpcli)
 	if err != nil {

--- a/shell.go
+++ b/shell.go
@@ -12,7 +12,6 @@ import (
 	"os"
 
 	files "github.com/whyrusleeping/go-multipart-files"
-
 	tar "github.com/whyrusleeping/tar-utils"
 )
 
@@ -74,7 +73,7 @@ func (s *Shell) ID(peer ...string) (*IdOutput, error) {
 }
 
 // Cat the content at the given path
-func (s *Shell) Cat(path string) (io.Reader, error) {
+func (s *Shell) Cat(path string) (io.ReadCloser, error) {
 	resp, err := NewRequest(s.url, "cat", path).Send(s.httpcli)
 	if err != nil {
 		return nil, err
@@ -83,14 +82,7 @@ func (s *Shell) Cat(path string) (io.Reader, error) {
 		return nil, resp.Error
 	}
 
-	r, w := io.Pipe()
-	go func() {
-		defer resp.Close()
-		defer w.Close()
-		io.Copy(w, resp.Output)
-	}()
-
-	return r, nil
+	return resp.Output, nil
 }
 
 type object struct {


### PR DESCRIPTION
beb4a5c: shell `Cat()` returns an io.ReadCloser to remove buffering and make the error visible
0d307b5: `Request.Send()` printed to stdout in an unhanded switch case