### PR TITLE
Convert *shell.Error to error before returning it

### DIFF
--- a/ipns.go
+++ b/ipns.go
@@ -17,7 +17,11 @@ func (s *Shell) Publish(node string, value string) error {
 	}
 	defer resp.Close()
 
-	return resp.Error
+	if resp.Error != nil {
+		return resp.Error
+	}
+
+	return nil
 }
 
 func (s *Shell) Resolve(id string) (string, error) {


### PR DESCRIPTION
Otherwise, error will not evaluate to nil unless casted to *shell.Error